### PR TITLE
Add short markdown file with a link to OCX-Ruby example

### DIFF
--- a/docs/emit-consume-example.md
+++ b/docs/emit-consume-example.md
@@ -1,0 +1,6 @@
+# Emitting/consuming data with OCX markup
+
+In order to operate on data wrapped in special markup using OCX specification, one may use libraries developed for different programming languages.
+Bellow is an example of how to do that with Ruby language:
+
+- [k12-ocx-ruby](https://github.com/K12OCX/k12-ocx-ruby)

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,10 @@ This specification comprises the following features:
 
 5. An additional set of [styling guides](styling) for allowing resources to keep visual integrity, or to change themes accordingly to different consumers.
 
+## Examples
+
+Examples for emitting or consuming the data using different programming languages can be found [here](emit-consume-example.md)
+
 ## IPR & License
 All materials are contributed under the [Apache 2](https://www.apache.org/licenses/LICENSE-2.0) license. Materials will be contributed per copyright title to The Bill and Melinda Gates Foundation, and all such contributions will be licensed openly per previous sentence.
 


### PR DESCRIPTION
Short link to instructions on how to consume or emit the data with OCX markup.

<img width="1130" alt="Скриншот 2019-03-14 16 38 54" src="https://user-images.githubusercontent.com/784577/54365568-bc8e3680-4677-11e9-952a-0efe741b29f1.png">

<img width="1133" alt="Скриншот 2019-03-14 16 38 32" src="https://user-images.githubusercontent.com/784577/54365575-c152ea80-4677-11e9-9614-ea5278ce9496.png">
